### PR TITLE
과목 정보 윈도우 제거 및 과목 버튼을 텍스트UI로 변경

### DIFF
--- a/inc/UIManager.h
+++ b/inc/UIManager.h
@@ -10,6 +10,9 @@
 #include <Windows.h>
 
 
+extern const char* creditsitems[];
+extern const char* gradeItems[];
+extern const char* categoryitems[];
 
 
 // UIManager.h
@@ -26,7 +29,7 @@ private:
     bool m_showToastMessege = false;
     int start_frame = 0; // 알림이 시작된 프레임 번호
     const int VISIBLE_FRAMES = 180;  // 완전히 보이는 프레임 수 (약 1초)
-    const int FADE_FRAMES = 240;    // 사라지는 데 걸리는 프레임 수 (약 2초)
+    const int FADE_FRAMES = 240;    // 사라지는 데 걸리는 프레임 수 (약 2초)  
 
 public:
     UIManager(GradeManager& manager);
@@ -34,10 +37,8 @@ public:
 
 
 private:
-    void displaySemestersWindow();  // 모든 학기 윈도우
-
-    void displayCoursesWindow(); // 한 학기의 과목 출력
-    void displayInfomationCourseWindow(const Course::Course& c);                             // 한 과목의 정보 출력
+    void displaySemestersWindow();                                  // 모든 학기 윈도우
+    void displayCoursesWindow();                                    // 한 학기의 과목 출력
 
     void promptValueCourseWindow(
       bool isInit, 
@@ -47,9 +48,7 @@ private:
 
     void displayToastMessege(std::string messege);
     void displayToastMessege_(const char* messege);
-
     void displayOptionBar(HWND& hwnd);
-
     void displayTotalGradeGraph();
 
     void alignCenter(const char* text);

--- a/src/UIManager.cpp
+++ b/src/UIManager.cpp
@@ -287,7 +287,6 @@ void UIManager::displayOptionBar(HWND& hwnd)
             }
 
             ImGui::Separator();
-
             ImGui::EndMenu();
         }
 
@@ -413,22 +412,22 @@ void UIManager::displayCoursesWindow()
 
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex(0);
-        if(ImGui::Button("과목이름"))
+        if(centerAlignButton("과목이름"))
         {
             gm.handleSortCourse(1);
         }
         ImGui::TableSetColumnIndex(1);
-        if(ImGui::Button("이수학점"))
+        if(centerAlignButton("이수학점"))
         {
             gm.handleSortCourse(2);
         }
         ImGui::TableSetColumnIndex(2);
-        if(ImGui::Button("받은점수"))
+        if(centerAlignButton("받은점수"))
         {
             gm.handleSortCourse(3);
         }
         ImGui::TableSetColumnIndex(3);
-        if(ImGui::Button("전공분류"))
+        if(centerAlignButton("전공분류"))
         {
             gm.handleSortCourse(4);
         }
@@ -442,11 +441,7 @@ void UIManager::displayCoursesWindow()
 
 
             ImGui::TableSetColumnIndex(0);
-            if (ImGui::Button(c.courseName.c_str()))
-            {
-                gm.setSelectCourse(c);
-            }
-
+            ImGui::Text(c.courseName.c_str());
 
             ImGui::TableSetColumnIndex(1);
             ImGui::Text(std::to_string(c.credits).c_str());
@@ -618,58 +613,3 @@ void UIManager::promptValueCourseWindow(
 
     ImGui::End();
 }
-
-
-
-
-/*
-// 한 과목의 정보 출력 윈도우
-void UIManager::displayInfomationCourseWindow(const Course::Course& c)
-{
-    ImGui::Begin(('[' + c.courseName + "] 정보 조회").c_str(), &m_courseReadWindow);
-
-    if (ImGui::BeginTable("courseInfoTable", 2, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_RowBg))
-    {
-        // 열 너비 설정: 첫 열은 고정, 두 번째 열은 나머지 공간 차지
-        ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed, 150.0f);
-        ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
-
-        // --- 과목명 행 ---
-        ImGui::TableNextRow();
-        ImGui::TableSetColumnIndex(0);
-        // 첫 번째 열의 텍스트도 가운데 정렬
-        alignCenter("과목명");
-        ImGui::TableSetColumnIndex(1);
-        ImGui::TextUnformatted(c.courseName.c_str());
-
-        // --- 이수학점 행 ---
-        ImGui::TableNextRow();
-        ImGui::TableSetColumnIndex(0);
-        alignCenter("이수학점");
-        ImGui::TableSetColumnIndex(1);
-        std::string creditsStr = std::to_string(c.credits);
-        ImGui::TextUnformatted(creditsStr.c_str());
-
-        // --- 받은점수 행 ---
-        ImGui::TableNextRow();
-        ImGui::TableSetColumnIndex(0);
-        alignCenter("받은점수");
-        ImGui::TableSetColumnIndex(1);
-        char gradeBuf[16];
-        snprintf(gradeBuf, sizeof(gradeBuf), "%.2f", c.grade);
-        ImGui::TextUnformatted(gradeBuf);
-
-        // --- 전공분류 행 ---
-        ImGui::TableNextRow();
-        ImGui::TableSetColumnIndex(0);
-        alignCenter("전공분류");
-        ImGui::TableSetColumnIndex(1);
-        std::string categoryStr = Course::categoryToString(c.category);
-        ImGui::TextUnformatted(categoryStr.c_str());
-
-        ImGui::EndTable();
-    }
-
-    ImGui::End();                            
-}
-*/


### PR DESCRIPTION
## 🧐 어떤 기능인가요?
- 기존 과목 이름이 버튼 UI로 되어있으며, 클릭 시 과목 정보가 나타나도록 함
- 과목 정보를 띄우지 않기로 결정하였으며, 이에 따라 버튼 UI를 텍스트 UI로 변경

## 🔨 작업 내용
- `UIManager`에서 `void displayInfomationCourseWindow(const Course::Course& c);` 함수 제거
- `UIManager`에서 `ImGui::Text(c.courseName.c_str());`로 과목 이름을 Text UI로 출력되도록 변경

## 📷 스크린샷
<img width="837" height="207" alt="image" src="https://github.com/user-attachments/assets/21416b53-bd8a-4cf5-b834-b3114c499f69" />


## 💬 기타
- ImGui 입력(드롭박스 등)을 위한 전역 변수가 UIManager.cpp파일에만 존재
- UIManager.h파일에 `extern`로 추가하여 정의
